### PR TITLE
Includes resources dir in "Copy app files" section

### DIFF
--- a/documentation/service-war-deployment.md
+++ b/documentation/service-war-deployment.md
@@ -136,7 +136,7 @@ Getting dependencies:
 Copying your application files:
 
     mkdir -p target/war/WEB-INF/classes
-    cp -R src/* config/* target/war/WEB-INF/classes
+    cp -R src/* config/* resources/* target/war/WEB-INF/classes
 
 Copying `web.xml`:
 


### PR DESCRIPTION
Not including the resources dir in the war could cause an exception when using io/resource:

"java.lang.IllegalArgumentException: No implementation of method: :make-reader of protocol: #'clojure.java.io/IOFactory found for class: nil"